### PR TITLE
Updated loadMetaData to search for metadata file using rom header. Added RomHeader.

### DIFF
--- a/gbahack/gbabin/rom.py
+++ b/gbahack/gbabin/rom.py
@@ -4,6 +4,7 @@ from gbahack.resource import ResourceManager
 
 import json
 import os
+import glob
 from array import array
 
 class NoMetaDataException(Exception):
@@ -63,7 +64,11 @@ class ROM(RawFile):
     def __init__(self, filename, metadata=None):
         RawFile.__init__(self, filename)
         self.filename = filename
-    
+        self.RomHeader = {
+            "headerCode": self.readBytes(0xAC, 4)[1].decode('utf-8'),
+            "headerName": self.readBytes(0xA0, 12)[1].decode('utf-8'),
+            "headerMaker": self.readBytes(0xB0, 2)[1].decode('utf-8')
+        }
         self.metadata = {}
         if metadata != None:
             self.metadata = metadata
@@ -77,8 +82,15 @@ class ROM(RawFile):
         self.metadata = {}
     
         #try to find a metadata rom definition
+        
+        romsPath = os.getcwd().split('\\')[-1]+"/roms/"
+        shortName = self.RomHeader["headerName"].split(" ")[1].lower()
+        metaFiles = glob.glob(romsPath+shortName+"*.metadata") #we do this because shortName != filename
+        
         metafile = None
-        if os.path.isfile(self.filename+".metadata"):
+        if len(metaFiles)>0:
+             metafile = metaFiles[0]
+        elif os.path.isfile(self.filename+".metadata"):
             metafile = self.filename+".metadata"
         elif os.path.isfile(os.path.splitext(self.filename)[0]+".metadata"):
             metafile = os.path.splitext(self.filename)[0]+".metadata"

--- a/gbahack/gbabin/rom.py
+++ b/gbahack/gbabin/rom.py
@@ -1,4 +1,3 @@
-
 from gbahack.gbabin.bytes import ByteArrayReader
 from gbahack.resource import ResourceManager
 
@@ -88,7 +87,7 @@ class ROM(RawFile):
         metaFiles = glob.glob(romsPath+shortName+"*.metadata") #we do this because shortName != filename
         
         metafile = None
-        if len(metaFiles)>0:
+        if (len(metaFiles)==1):
              metafile = metaFiles[0]
         elif os.path.isfile(self.filename+".metadata"):
             metafile = self.filename+".metadata"


### PR DESCRIPTION
I used the readBytes function to get basic info off the top of the rom commonly referred to at the rom header, thus named RomHeader. It contains information like the game code (four characters), the game short name, and the manufacturer id corresponding to GBA. Also I changed the loadMetaData function to refer to the rom short name for help finding the metadata file in the roms folder.
TODO: change roms folder from config
